### PR TITLE
More screen artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 t ?= esp32
 
-#TERMINAL_EXTRA_FLAGS := -C serialout.txt
+TERMINAL_EXTRA_FLAGS := -C serialout.txt
 #CPPFLAGS = -DDEBUGGING=0x32
 CPPFLAGS += -DNO_STORAGE -DNO_SPIRAM
 LIBRARIES = SPI PS2KeyRaw Adafruit_GFX Adafruit_BusIO Wire

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 t ?= esp32
 
-TERMINAL_EXTRA_FLAGS := -C serialout.txt
+#TERMINAL_EXTRA_FLAGS := -C serialout.txt
 #CPPFLAGS = -DDEBUGGING=0x32
 CPPFLAGS += -DNO_STORAGE -DNO_SPIRAM
 LIBRARIES = SPI PS2KeyRaw Adafruit_GFX Adafruit_BusIO Wire

--- a/io.cpp
+++ b/io.cpp
@@ -115,6 +115,7 @@ void IO::checkpoint(Checkpoint &c) {
 	c.write(_int_enabled);
 	c.write(_sound_enabled);
 	c.write(_screen_flipped);
+	c.write(_vec);
 }
 
 void IO::restore(Checkpoint &c) {
@@ -122,4 +123,5 @@ void IO::restore(Checkpoint &c) {
 	c.read(_int_enabled);
 	c.read(_sound_enabled);
 	c.read(_screen_flipped);
+	c.read(_vec);
 }

--- a/io.h
+++ b/io.h
@@ -61,9 +61,12 @@ public:
 	bool screen_flipped() const { return _screen_flipped; }
 	bool paused() const { return _paused; }
 	void pause() { _paused = true; }
+	uint8_t vec() const { return _vec; }
+	void vec(uint8_t b) { _vec = b; }
 
 private:
 	uint8_t _sx;
+	uint8_t _vec;
 
 	bool _up, _down, _left, _right, _coin, _p1_start, _p2_start;
 	bool _int_enabled, _sound_enabled, _screen_flipped, _paused;

--- a/pacman.ino
+++ b/pacman.ino
@@ -35,16 +35,14 @@ void setup(void) {
 	Serial.begin(TERMINAL_SPEED);
 #endif
 
-	static uint8_t vec;
-
 	cpu.set_port_out_handler([](uint16_t p, uint8_t b) {
 		if ((p & 0xff) == 0x0000)
-			vec = b;
+			io.vec(b);
 	});
 
 	machine.begin();
 
-	machine.interval_timer(1000000 / 60, []() { cpu.irq(vec); });
+	machine.interval_timer(1000000 / 60, []() { cpu.irq(io.vec()); });
 
 	memory.put(e6, 0x0000);
 	memory.put(f6, 0x1000);

--- a/screen.cpp
+++ b/screen.cpp
@@ -70,11 +70,19 @@ void Screen::_set(uint16_t a, uint8_t b) {
 		_grid[y][x] = a;
 }
 
-void Screen::_erase_sprite(int ox, int oy) {
+void Screen::_erase_sprite(int ox, int oy, int nx, int ny) {
 	for (int row = oy/8; row <= (oy+15)/8; row++)
-		for (int col = ox/8; col <= (ox+15)/8; col++)
-			if (row >= 0 && row < TILE_ROWS && col >= 0 && col < TILE_COLS && _grid[row][col] != 0xffff)
-				draw_tile(_grid[row][col], 8*col, 8*row);
+		for (int col = ox/8; col <= (ox+15)/8; col++) {
+			if (row < 0 || row >= TILE_ROWS || col < 0 || col >= TILE_COLS)
+				continue;
+			int cx = col*8, cy = row*8;
+			// skip cells the sprite's new position will draw over anyway
+			bool covered = (cx < nx+16 && cx+8 > nx && cy < ny+16 && cy+8 > ny);
+			if (!covered && _grid[row][col] != 0xffff) {
+				draw_tile(_grid[row][col], cx, cy);
+				_machine->yield();
+			}
+		}
 }
 
 void Screen::set_sprite(uint16_t off, uint8_t sx, uint8_t sy) {
@@ -84,7 +92,7 @@ void Screen::set_sprite(uint16_t off, uint8_t sx, uint8_t sy) {
 
 	// fold the 16-slot I/O mirror (SPRITE_LEN=0x20) onto the 8 real sprites
 	uint8_t slot = (off/2) % NUM_SPRITES;
-	_erase_sprite(_spr_x[slot], _spr_y[slot]);
+	_erase_sprite(_spr_x[slot], _spr_y[slot], x, y);
 	_spr_x[slot] = x;
 	_spr_y[slot] = y;
 
@@ -119,6 +127,7 @@ void Screen::set_sprite(uint16_t off, uint8_t sx, uint8_t sy) {
 			}
 		break;
 	}
+	_machine->yield();
 }
 
 void Screen::checkpoint(Checkpoint &c) {
@@ -139,6 +148,9 @@ void Screen::restore(Checkpoint &c) {
 
 void Screen::redraw() {
 	Display::clear();
-	for (unsigned i = 0; i < sizeof(_tp); i++)
+	for (unsigned i = 0; i < sizeof(_tp); i++) {
 		_set(i, _tp[i]);
+		if ((i & 0x3f) == 0)
+			_machine->yield();
+	}
 }

--- a/screen.cpp
+++ b/screen.cpp
@@ -1,4 +1,3 @@
-#include <Arduino.h>
 #include <machine.h>
 #include <memory.h>
 #include <hardware.h>
@@ -67,12 +66,27 @@ void Screen::_set(uint16_t a, uint8_t b) {
 		y = 1;
 	}
 	draw_tile(a, 8*x, 8*y);
+	if (y >= 0 && y < TILE_ROWS && x >= 0 && x < TILE_COLS)
+		_grid[y][x] = a;
+}
+
+void Screen::_erase_sprite(int ox, int oy) {
+	for (int row = oy/8; row <= (oy+15)/8; row++)
+		for (int col = ox/8; col <= (ox+15)/8; col++)
+			if (row >= 0 && row < TILE_ROWS && col >= 0 && col < TILE_COLS && _grid[row][col] != 0xffff)
+				draw_tile(_grid[row][col], 8*col, 8*row);
 }
 
 void Screen::set_sprite(uint16_t off, uint8_t sx, uint8_t sy) {
 
 	int x = DISPLAY_WIDTH - sx + 15;
 	int y = DISPLAY_HEIGHT - sy - 16;
+
+	// fold the 16-slot I/O mirror (SPRITE_LEN=0x20) onto the 8 real sprites
+	uint8_t slot = (off/2) % NUM_SPRITES;
+	_erase_sprite(_spr_x[slot], _spr_y[slot]);
+	_spr_x[slot] = x;
+	_spr_y[slot] = y;
 
 	const uint8_t pindex = _mem[0x4ff1 + off];
 	uint8_t sir = _mem[0x4ff0 + off];
@@ -83,7 +97,7 @@ void Screen::set_sprite(uint16_t off, uint8_t sx, uint8_t sy) {
 	case 0: // no flip
 		for (int px = x; px <= x+15; px++)
 			for (int py = y; py <= y+15; py++) {
-				if (px >= 0 && px <= 223)
+				if (px >= 0 && px < DISPLAY_WIDTH)
 					Display::drawPixel(px, py, _palette565[pindex][pgm_read_byte(cdata)]);
 				cdata++;
 			}
@@ -91,47 +105,36 @@ void Screen::set_sprite(uint16_t off, uint8_t sx, uint8_t sy) {
 	case 1: // flip y
 		for (int px = x; px <= x+15; px++)
 			for (int py = y+15; py >= y; py--) {
-				Display::drawPixel(px, py, _palette565[pindex][pgm_read_byte(cdata)]);
+				if (px >= 0 && px < DISPLAY_WIDTH)
+					Display::drawPixel(px, py, _palette565[pindex][pgm_read_byte(cdata)]);
 				cdata++;
 			}
 		break;
 	case 2: // flip x
 		for (int px = x+15; px >= x; px--)
 			for (int py = y; py <= y+15; py++) {
-				if (px >= 0 && px <= 223)
+				if (px >= 0 && px < DISPLAY_WIDTH)
 					Display::drawPixel(px, py, _palette565[pindex][pgm_read_byte(cdata)]);
 				cdata++;
 			}
 		break;
 	}
-
-	if (sid >= 44 && sid <= 48) {
-		DBG_DSP("pacman at %d,%d flip=%d", x, y, sir & 0x03);
-
-		static int opx, opy;
-
-		int dx = x - opx;
-		if (dx > 1)
-			Display::drawFastVLine(x-1, y+2, 12, BLACK);
-		else if (dx < -1)
-			Display::drawFastVLine(x+16, y+2, 12, BLACK);
-		opx = x;
-
-		int dy = y - opy;
-		if (dy > 1)
-			Display::drawFastHLine(x+2, y-1, 12, BLACK);
-		else if (dy < -1)
-			Display::drawFastHLine(x+2, y+16, 12, BLACK);
-		opy = y;
-	}
 }
 
 void Screen::checkpoint(Checkpoint &c) {
 	c.write(_tp, sizeof(_tp));
+	for (unsigned i = 0; i < NUM_SPRITES; i++) {
+		c.write((uint16_t)_spr_x[i]);
+		c.write((uint16_t)_spr_y[i]);
+	}
 }
 
 void Screen::restore(Checkpoint &c) {
 	c.read(_tp, sizeof(_tp));
+	for (unsigned i = 0; i < NUM_SPRITES; i++) {
+		c.read((uint16_t &)_spr_x[i]);
+		c.read((uint16_t &)_spr_y[i]);
+	}
 }
 
 void Screen::redraw() {

--- a/screen.h
+++ b/screen.h
@@ -41,7 +41,7 @@ class Screen: public Display, public Memory::Device {
 public:
 	Screen(Memory &mem): Memory::Device(sizeof(_tp)), _mem(mem) {
 		for (int i = 0; i < NUM_SPRITES; i++)
-			_spr_x[i] = _spr_y[i] = -100;		// sentinel: nothing drawn there yet
+			_spr_x[i] = _spr_y[i] = -100;	// sentinel: nothing drawn there yet
 		for (int y = 0; y < TILE_ROWS; y++)
 			for (int x = 0; x < TILE_COLS; x++)
 				_grid[y][x] = 0xffff;		// sentinel: no tile mapped to this cell yet
@@ -60,11 +60,11 @@ public:
 private:
 	void _set(uint16_t a, uint8_t b);
 	void draw_tile(uint16_t addr, int x, int y);
-	void _erase_sprite(int x, int y);
+	void _erase_sprite(int ox, int oy, int nx, int ny);
 
 	uint8_t _tp[2048];
 	uint16_t _palette565[32][4];
-	uint16_t _grid[TILE_ROWS][TILE_COLS];			// tile-RAM address occupying each screen cell
+	uint16_t _grid[TILE_ROWS][TILE_COLS];		// tile-RAM address occupying each screen cell
 	int16_t _spr_x[NUM_SPRITES], _spr_y[NUM_SPRITES];	// previous screen position per sprite slot
 
 	Memory &_mem;

--- a/screen.h
+++ b/screen.h
@@ -3,6 +3,10 @@
 #define DISPLAY_WIDTH	224
 #define DISPLAY_HEIGHT	288
 
+#define TILE_COLS	28
+#define TILE_ROWS	36
+#define NUM_SPRITES	8
+
 class colour {
 public:
 	uint8_t red, green, blue;
@@ -35,7 +39,13 @@ public:
 
 class Screen: public Display, public Memory::Device {
 public:
-	Screen(Memory &mem): Memory::Device(sizeof(_tp)), _mem(mem) {}
+	Screen(Memory &mem): Memory::Device(sizeof(_tp)), _mem(mem) {
+		for (int i = 0; i < NUM_SPRITES; i++)
+			_spr_x[i] = _spr_y[i] = -100;		// sentinel: nothing drawn there yet
+		for (int y = 0; y < TILE_ROWS; y++)
+			for (int x = 0; x < TILE_COLS; x++)
+				_grid[y][x] = 0xffff;		// sentinel: no tile mapped to this cell yet
+	}
 
 	void operator=(uint8_t b) override { if (_tp[_acc] != b) _set(_acc, b); }
 	operator uint8_t() override { return _tp[_acc]; }
@@ -50,9 +60,12 @@ public:
 private:
 	void _set(uint16_t a, uint8_t b);
 	void draw_tile(uint16_t addr, int x, int y);
+	void _erase_sprite(int x, int y);
 
 	uint8_t _tp[2048];
 	uint16_t _palette565[32][4];
+	uint16_t _grid[TILE_ROWS][TILE_COLS];			// tile-RAM address occupying each screen cell
+	int16_t _spr_x[NUM_SPRITES], _spr_y[NUM_SPRITES];	// previous screen position per sprite slot
 
 	Memory &_mem;
 };


### PR DESCRIPTION
## Fix ghost/sprite trails on maze background (#9)

### Problem
Sprites (ghosts, fruit, etc.) were drawn directly over the maze background
with no mechanism to restore the tile artwork underneath once a sprite moved
away, leaving visible trails/artifacts. The only existing erase logic was a
narrow, Pac-Man-specific hack (`sid >= 44 && sid <= 48`) that painted black
lines to hide 1px trailing edges from Pac-Man's own sprite — it never applied
to ghosts, and even for Pac-Man it approximated erasure with black rather
than restoring the actual tile.

### Fix
- Track each of the 8 physical sprite slots' previous screen position
  (`_spr_x`/`_spr_y`), keyed by `(off/2) % NUM_SPRITES` to safely fold the
  16-slot I/O mirror (`SPRITE_LEN=0x20`) onto the real 8 hardware sprites.
- Add a reverse tile-lookup grid (`_grid[TILE_ROWS][TILE_COLS]`), populated
  as a side effect of `_set()`, recording which tile-RAM address occupies
  each screen cell.
- Before drawing a sprite at its new position, `_erase_sprite()` redraws
  (from the cache, via `draw_tile()`) every tile cell the sprite's *old*
  bounding box covered — using real tile artwork instead of black lines —
  skipping any cell the sprite's *new* position will immediately draw over
  anyway, to cut redundant work during normal slow movement.
- Removed the old Pac-Man-only black-line hack; Pac-Man is now just one of
  the 8 sprite slots and goes through the same general path.
- `_spr_x`/`_spr_y` are checkpointed/restored; `_grid` isn't (it's fully
  repopulated by `redraw()`'s existing full-screen walk over `_tp`, which
  runs after machine state restore).

### Related fix found in the same code
`set_sprite()`'s `flip y` case was missing the horizontal clip
(`px >= 0 && px < DISPLAY_WIDTH`) that the other two flip cases already had
— a vertically-flipped sprite crossing the screen edge could call
`Display::drawPixel` out of bounds. Added it.

### ESP8266 watchdog fix
The extra tile-redraw work above increased per-frame drawing time enough to
trip the WDT on ESP8266, most visibly during the attract-mode chase sequence
(sustained multi-sprite movement — the worst case for the overlap-skip
optimization above, since fast/large movement means little old/new bounding
box overlap to skip). Added `_machine->yield()` calls at three granularities:
per erased tile in `_erase_sprite()`, once per sprite in `set_sprite()`, and
every 64 tiles in `redraw()`'s full-screen repaint path.

### Testing
- Verified ghosts and Pac-Man no longer leave trails during normal play.
- Verified checkpoint/restore mid-game (with ghosts on screen) redraws
  correctly on the following frame.
- Reproduced and confirmed fix for the ESP8266 WDT reset during the
  attract-mode power-pill chase sequence.
- Further soak testing in progress (heavier multi-sprite scenes, checking
  for any visible tearing from mid-frame `yield()`).

Costs: ~2KB RAM for `_grid` (`TILE_ROWS*TILE_COLS*2` bytes), 32 bytes for
`_spr_x`/`_spr_y`.